### PR TITLE
Fix build: commons-io artifact ID changed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'org.apache.commons:commons-io:1.3.2'
+    compile 'commons-io:commons-io:1.3.2'
     compile 'com.android.support:appcompat-v7:27.0.2'
     compile 'com.android.support:support-v13:27.0.2'
     compile 'com.android.support:design:27.0.2'


### PR DESCRIPTION
Apache changed artifact ID for commons-io package
(https://commons.apache.org/proper/commons-io/dependency-info.html),
so project builds (both release and debug) failed.

Signed-off-by: Lesya Novaselskaya <shams@airpost.net>